### PR TITLE
Fix Next.js build by installing missing TypeScript type packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,8 @@
   },
   "devDependencies": {
     "typescript": "^5.4.0",
+    "@types/react": "^18.2.0",
+    "@types/node": "^20.11.0",
     "tailwindcss": "^3.4.2",
     "postcss": "^8.4.16",
     "autoprefixer": "^10.4.2",


### PR DESCRIPTION
## Summary
- add `@types/react` and `@types/node` to dev dependencies

## Testing
- `npm run build` *(fails: `next` not found because dependencies are not installed)*

------
https://chatgpt.com/codex/tasks/task_e_683de73acd7c8333b292c5441b130aa2