### PR TITLE
Replace language dropdown with flag tabs

### DIFF
--- a/app/components/TypingTrainer.tsx
+++ b/app/components/TypingTrainer.tsx
@@ -3,6 +3,19 @@ import { useEffect, useState } from 'react';
 import dictionaries, { Language } from '../data/dictionaries';
 import confetti from 'canvas-confetti';
 
+const languageOptions: { code: Language; name: string; emoji: string }[] = [
+  { code: 'english', name: 'English', emoji: '🇺🇸' },
+  { code: 'hebrew', name: 'Hebrew', emoji: '🇮🇱' },
+  { code: 'german', name: 'German', emoji: '🇩🇪' },
+  { code: 'chinese', name: 'Chinese', emoji: '🇨🇳' },
+  { code: 'spanish', name: 'Spanish', emoji: '🇪🇸' },
+  { code: 'arabic', name: 'Arabic', emoji: '🇸🇦' },
+  { code: 'hindi', name: 'Hindi', emoji: '🇮🇳' },
+  { code: 'telugu', name: 'Telugu', emoji: '🇮🇳' },
+  { code: 'russian', name: 'Russian', emoji: '🇷🇺' },
+  { code: 'japanese', name: 'Japanese', emoji: '🇯🇵' },
+];
+
 export default function TypingTrainer() {
   const [language, setLanguage] = useState<Language>('english');
   const [index, setIndex] = useState(0);
@@ -67,23 +80,22 @@ export default function TypingTrainer() {
 
   return (
     <div className="space-y-4">
-      <div>
-        <select
-          value={language}
-          onChange={(e) => setLanguage(e.target.value as Language)}
-          className="p-2 border rounded"
-        >
-          <option value="english">English</option>
-          <option value="hebrew">Hebrew</option>
-          <option value="german">German</option>
-          <option value="chinese">Chinese</option>
-          <option value="spanish">Spanish</option>
-          <option value="arabic">Arabic</option>
-          <option value="hindi">Hindi</option>
-          <option value="telugu">Telugu</option>
-          <option value="russian">Russian</option>
-          <option value="japanese">Japanese</option>
-        </select>
+      <div className="flex flex-wrap gap-2">
+        {languageOptions.map((opt) => (
+          <button
+            key={opt.code}
+            onClick={() => setLanguage(opt.code)}
+            className={
+              `px-3 py-1 rounded-full border text-sm flex items-center gap-1 ` +
+              (language === opt.code
+                ? 'bg-blue-500 text-white border-blue-500'
+                : 'bg-white hover:bg-gray-100')
+            }
+          >
+            <span>{opt.emoji}</span>
+            <span>{opt.name}</span>
+          </button>
+        ))}
       </div>
       {speed && (
         <div className="text-center text-xl font-bold">


### PR DESCRIPTION
## Summary
- switch language select to pill-style buttons with flag emoji

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_683dedefb0688333b6f8a883a5b0485d