### PR TITLE
Fix export type in dictionaries

### DIFF
--- a/app/data/dictionaries.ts
+++ b/app/data/dictionaries.ts
@@ -232,4 +232,5 @@ export function randomSentence(lang: Language): string {
 // console.log(randomSentence("spanish"));
 // console.log(randomSentence("chinese"));
 
-export { Language, wordBank };
+export type { Language };
+export { wordBank };


### PR DESCRIPTION
## Summary
- use `export type` for Language to satisfy isolatedModules

## Testing
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_683e8fad2dec8333b88e790e7cd52a63