### PR TITLE
Add popover carousel for language selection

### DIFF
--- a/app/components/TypingTrainer.tsx
+++ b/app/components/TypingTrainer.tsx
@@ -37,6 +37,7 @@ export default function TypingTrainer() {
   const [speed, setSpeed] = useState<number | null>(null);
 
   const [sentence, setSentence] = useState('');
+  const [showPicker, setShowPicker] = useState(false);
 
   useEffect(() => {
     const hash = window.location.hash.replace('#', '');
@@ -94,24 +95,43 @@ export default function TypingTrainer() {
 
   const isRTL = language === 'hebrew' || language === 'arabic';
 
+  const selectedOption = languageOptions.find((o) => o.code === language);
+
   return (
     <div className="space-y-4">
-      <div className="flex flex-wrap gap-2">
-        {languageOptions.map((opt) => (
-          <button
-            key={opt.code}
-            onClick={() => setLanguage(opt.code)}
-            className={
-              `px-3 py-1 rounded-full border text-sm flex items-center gap-1 ` +
-              (language === opt.code
-                ? 'bg-blue-500 text-white border-blue-500'
-                : 'bg-white hover:bg-gray-100')
-            }
-          >
-            <span>{opt.emoji}</span>
-            <span>{opt.name}</span>
-          </button>
-        ))}
+      <div className="relative inline-block">
+        <button
+          onClick={() => setShowPicker((p) => !p)}
+          className="px-3 py-1 rounded-full border text-sm flex items-center gap-1 bg-white hover:bg-gray-100"
+        >
+          <span>{selectedOption?.emoji}</span>
+          <span>{selectedOption?.name}</span>
+          <span className="ml-1">▾</span>
+        </button>
+        {showPicker && (
+          <div className="absolute left-0 mt-2 w-max bg-white border rounded shadow p-2 z-10">
+            <div className="flex gap-2 overflow-x-auto max-w-xs">
+              {languageOptions.map((opt) => (
+                <button
+                  key={opt.code}
+                  onClick={() => {
+                    setLanguage(opt.code);
+                    setShowPicker(false);
+                  }}
+                  className={
+                    `px-3 py-1 rounded-full border text-sm flex items-center gap-1 ` +
+                    (language === opt.code
+                      ? 'bg-blue-500 text-white border-blue-500'
+                      : 'bg-white hover:bg-gray-100')
+                  }
+                >
+                  <span>{opt.emoji}</span>
+                  <span>{opt.name}</span>
+                </button>
+              ))}
+            </div>
+          </div>
+        )}
       </div>
       {speed && (
         <div className="text-center text-xl font-bold">


### PR DESCRIPTION
## Summary
- add a popover-style carousel to select languages

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_683eb66966348333b667b6f7b1e6738d