### PR TITLE
Add typing accuracy metric

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ The app will start in development mode on `http://localhost:3000`.
 
 - Displays over a thousand random sentences (around ten words each) for each supported language
 - Highlights correct letters in green, mistakes in red and the next character with a blue underline
-- Shows typing speed in characters per second after each sentence
+- Shows typing speed in characters per second and how many mistakes you made after each sentence
 - Fun confetti effect when you finish a sentence
 - Language choice reflected in the URL hash for easy sharing
 

--- a/app/components/TypingTrainer.tsx
+++ b/app/components/TypingTrainer.tsx
@@ -36,6 +36,8 @@ export default function TypingTrainer() {
   const [input, setInput] = useState('');
   const [startTime, setStartTime] = useState<number | null>(null);
   const [speed, setSpeed] = useState<number | null>(null);
+  const [mistakes, setMistakes] = useState(0);
+  const [resultMistakes, setResultMistakes] = useState<number | null>(null);
 
   const [sentence, setSentence] = useState('');
 
@@ -53,13 +55,23 @@ export default function TypingTrainer() {
   useEffect(() => {
     setInput('');
     setStartTime(null);
+    setMistakes(0);
+    setResultMistakes(null);
   }, [index, language]);
 
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     if (startTime === null && e.target.value.length === 1) {
       setStartTime(Date.now());
     }
-    setInput(e.target.value);
+    const newValue = e.target.value;
+    if (newValue.length > input.length) {
+      const idx = newValue.length - 1;
+      const char = newValue[idx];
+      if (idx >= sentence.length || char !== sentence[idx]) {
+        setMistakes(m => m + 1);
+      }
+    }
+    setInput(newValue);
   };
 
   useEffect(() => {
@@ -68,16 +80,18 @@ export default function TypingTrainer() {
         const seconds = (Date.now() - startTime) / 1000;
         const speedVal = sentence.length / seconds;
         setSpeed(speedVal);
+        setResultMistakes(mistakes);
         confetti();
       }
       const next = index + 1;
       setTimeout(() => setIndex(next), 500);
     }
-  }, [input, sentence, startTime, index]);
+  }, [input, sentence, startTime, index, mistakes]);
 
   useEffect(() => {
     setIndex(0);
     setSpeed(null);
+    setResultMistakes(null);
     window.location.hash = language;
   }, [language]);
 
@@ -105,6 +119,9 @@ export default function TypingTrainer() {
       {speed && (
         <div className="text-center text-xl font-bold">
           Speed: {speed.toFixed(2)} chars/sec
+          {resultMistakes !== null && (
+            <span className="ml-4">Mistakes: {resultMistakes}</span>
+          )}
         </div>
       )}
       <div


### PR DESCRIPTION
## Summary
- compute typing mistakes and show them next to speed
- document the accuracy metric in the README

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_683ed7ec8cf48333b1c619d4d45ff264