### PR TITLE
Add English dictionary

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Multilingual Typing Trainer
 
-This is a small single page application for practicing blind keyboard typing. Originally focused on Hebrew, it now offers dictionaries for more than twenty languages including German, Chinese, Spanish, Arabic, Hindi, Telugu, Russian, Japanese, Thai, Korean, Armenian, Farsi, Greek, Ukrainian, Georgian, Gujarati, Burmese, Khmer, Sanskrit, Tibetan, Urdu and Marathi. The interface is in English and the sentences are shown in the selected language. It is built with **Next.js**, **React** and **Tailwind CSS** and can be deployed easily to Vercel.
+This is a small single page application for practicing blind keyboard typing. Originally focused on Hebrew, it now offers dictionaries for more than twenty languages including English, German, Chinese, Spanish, Arabic, Hindi, Telugu, Russian, Japanese, Thai, Korean, Armenian, Farsi, Greek, Ukrainian, Georgian, Gujarati, Burmese, Khmer, Sanskrit, Tibetan, Urdu and Marathi. The interface is in English and the sentences are shown in the selected language. It is built with **Next.js**, **React** and **Tailwind CSS** and can be deployed easily to Vercel.
 
 ## Development
 

--- a/app/components/TypingTrainer.tsx
+++ b/app/components/TypingTrainer.tsx
@@ -5,6 +5,7 @@ import confetti from 'canvas-confetti';
 import LanguageSelector from './LanguageSelector';
 
 const languageOptions: { code: Language; name: string; emoji: string }[] = [
+  { code: 'english', name: 'English', emoji: '🇬🇧' },
   { code: 'hebrew', name: 'Hebrew', emoji: '🇮🇱' },
   { code: 'german', name: 'German', emoji: '🇩🇪' },
   { code: 'chinese', name: 'Chinese', emoji: '🇨🇳' },

--- a/app/data/dictionaries.ts
+++ b/app/data/dictionaries.ts
@@ -12,7 +12,8 @@ type BaseLanguage =
   | "arabic"
   | "german"
   | "spanish"
-  | "hindi";
+  | "hindi"
+  | "english";
 
 type ExtraLanguage =
   | "thai"
@@ -202,6 +203,32 @@ const baseWordBank: Record<BaseLanguage, WordCategories> = {
     ],
     prepositions: [
       "में","से","तक","और","के बारे में","के लिए","क्योंकि","के माध्यम से","जैसे","की ओर"
+    ]
+  },
+
+  /* ---------- ENGLISH ---------- */
+  english: {
+    nouns: [
+      "cat","dog","child","teacher","student","city","mountain","river","sky","computer",
+      "phone","book","car","music","movie","flower","tree","ocean","friend","time",
+      "family","work","school","food","story","dream","heart","world","language","journey"
+    ],
+    verbs: [
+      "eat","drink","run","walk","see","hear","write","read","speak","laugh",
+      "cry","sleep","learn","teach","play","sing","dance","swim","draw","think",
+      "create","search","discover","share","help","change","remember","forget","begin","finish"
+    ],
+    adjectives: [
+      "beautiful","happy","fast","slow","tall","short","new","old","quiet","loud",
+      "warm","cold","simple","complex","bright","dark","strong","soft","rich","empty"
+    ],
+    adverbs: [
+      "gently","quickly","slowly","quietly","suddenly",
+      "often","sometimes","seriously","bravely","secretly"
+    ],
+    prepositions: [
+      "in","from","to","and","about",
+      "for","because","through","like","toward"
     ]
   }
 };


### PR DESCRIPTION
## Summary
- add English to language enum and word bank
- list English option in UI
- mention English in README

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_683ed8aa702483338986c33e6097a5e3