### PR TITLE
Update language selector UI

### DIFF
--- a/app/components/LanguageSelector.tsx
+++ b/app/components/LanguageSelector.tsx
@@ -11,40 +11,58 @@ interface Props {
 
 export default function LanguageSelector({ options, value, onChange }: Props) {
   const [open, setOpen] = useState(false);
+  const pinned = ['english', 'japanese', 'hebrew'];
+  const tabs = [value, ...pinned.filter(c => c !== value).slice(0, 2)] as Language[];
 
   return (
     <div className="relative w-full flex justify-center">
-      {/* Carousel when closed */}
+      {/* Tabs when closed */}
       {!open && (
-        <div className="relative flex items-center select-none px-10 overflow-x-auto gap-6 scroll-smooth">
-          {options.map(opt => (
-            <button
-              key={opt.code}
-              className={'whitespace-nowrap transition ' + (opt.code === value ? 'text-blue-600 font-bold' : 'text-gray-500')}
-              onClick={() => setOpen(true)}
-            >
-              {opt.name}
-            </button>
-          ))}
+        <div className="flex gap-2">
+          {tabs.map(code => {
+            const opt = options.find(o => o.code === code);
+            if (!opt) return null;
+            return (
+              <button
+                key={code}
+                onClick={() => onChange(code)}
+                className={'px-3 py-1 rounded-md border transition ' + (code === value ? 'bg-blue-500 text-white' : 'bg-white text-gray-700 hover:bg-gray-100')}
+              >
+                {opt.name}
+              </button>
+            );
+          })}
+          <button
+            onClick={() => setOpen(true)}
+            className="px-3 py-1 rounded-md border bg-white text-gray-700 hover:bg-gray-100"
+          >
+            …
+          </button>
         </div>
       )}
       {/* Popup when open */}
       {open && (
-        <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-20">
-          <div className="bg-white p-6 rounded-2xl shadow max-w-2xl w-full">
-            <div className="flex justify-between items-center mb-4">
-              <h2 className="font-bold">Select Language</h2>
-              <button onClick={() => setOpen(false)} className="text-xl">×</button>
-            </div>
-            <div className="grid grid-cols-4 gap-2">
+        <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-20 p-4">
+          <div className="bg-white p-6 rounded-2xl shadow w-full max-w-screen-lg">
+            <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-6 gap-4">
               {options.map(opt => (
                 <button
                   key={opt.code}
-                  onClick={() => { onChange(opt.code); setOpen(false); }}
-                  className={'border rounded p-2 flex items-center gap-1 ' + (value === opt.code ? 'bg-blue-500 text-white border-blue-500' : 'bg-white hover:bg-gray-100')}
+                  onClick={() => {
+                    onChange(opt.code);
+                    setOpen(false);
+                  }}
+                  className="flex flex-col items-center justify-center aspect-square"
                 >
-                  <span>{opt.emoji}</span>
-                  <span>{opt.name}</span>
+                  <div
+                    className={
+                      'w-16 h-16 flex items-center justify-center rounded-full border ' +
+                      (value === opt.code ? 'bg-blue-200' : 'bg-gray-100')
+                    }
+                  >
+                    <span className="text-2xl">{opt.emoji}</span>
+                  </div>
+                  <span className="mt-2 text-sm">{opt.name}</span>
                 </button>
               ))}
             </div>

--- a/app/components/TypingTrainer.tsx
+++ b/app/components/TypingTrainer.tsx
@@ -5,6 +5,7 @@ import confetti from 'canvas-confetti';
 import LanguageSelector from './LanguageSelector';
 
 const languageOptions: { code: Language; name: string; emoji: string }[] = [
+  { code: 'english', name: 'English', emoji: '🇺🇸' },
   { code: 'hebrew', name: 'Hebrew', emoji: '🇮🇱' },
   { code: 'german', name: 'German', emoji: '🇩🇪' },
   { code: 'chinese', name: 'Chinese', emoji: '🇨🇳' },

--- a/app/data/dictionaries.ts
+++ b/app/data/dictionaries.ts
@@ -4,6 +4,7 @@
  */
 
 type BaseLanguage =
+  | "english"
   | "chinese"
   | "japanese"
   | "hebrew"
@@ -43,6 +44,28 @@ interface WordCategories {
 /* -------- WORD BANK -------- */
 
 const baseWordBank: Record<BaseLanguage, WordCategories> = {
+  english: {
+    nouns: [
+      "cat","dog","child","teacher","student","city","mountain","river","sky","computer","phone","book",
+      "car","music","movie","flower","tree","sea","friend","time","family","work","school","food",
+      "story","dream","heart","world","language","journey"
+    ],
+    verbs: [
+      "eat","drink","run","walk","see","hear","write","read","talk","laugh","cry","sleep","learn","teach","play",
+      "sing","dance","swim","draw","think","create","search","discover","share","help","change","remember","forget",
+      "begin","end"
+    ],
+    adjectives: [
+      "beautiful","happy","fast","slow","tall","short","new","old","quiet","noisy","warm","cold",
+      "simple","complex","bright","dark","strong","soft","rich","empty"
+    ],
+    adverbs: [
+      "gently","quickly","slowly","quietly","suddenly","often","sometimes","seriously","bravely","secretly"
+    ],
+    prepositions: [
+      "in","from","to","with","about","for","because","through","like","at"
+    ]
+  },
   chinese: {
     nouns: [
       "猫","狗","孩子","老师","学生","城市","山","河","天空","电脑","手机","书","汽车","音乐","电影","花","树","海洋","朋友","时间","家庭","工作","学校","食物","故事","梦想","心","世界","语言","旅程"


### PR DESCRIPTION
## Summary
- add English language dataset
- expand language options list
- redesign language selector as tabs with popup card layout

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_683eda6936a48333be23f3b77cf16544