### PR TITLE
Remove pronunciation hint from trainer card

### DIFF
--- a/app/components/HebrewLetterTrainer.tsx
+++ b/app/components/HebrewLetterTrainer.tsx
@@ -1,0 +1,137 @@
+'use client';
+
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { formatSounds, hebrewLetters } from '../data/hebrewLetters';
+
+type Score = {
+  correct: number;
+  incorrect: number;
+};
+
+const INITIAL_SCORE: Score = { correct: 0, incorrect: 0 };
+
+const pickRandomIndex = (exclude?: number) => {
+  let nextIndex = Math.floor(Math.random() * hebrewLetters.length);
+  if (typeof exclude === 'number' && hebrewLetters.length > 1) {
+    while (nextIndex === exclude) {
+      nextIndex = Math.floor(Math.random() * hebrewLetters.length);
+    }
+  }
+  return nextIndex;
+};
+
+const buildOptionSet = (currentIndex: number) => {
+  const options = new Set<string>();
+  const correct = formatSounds(hebrewLetters[currentIndex].sounds);
+  options.add(correct);
+
+  while (options.size < 4) {
+    const randomIndex = Math.floor(Math.random() * hebrewLetters.length);
+    const option = formatSounds(hebrewLetters[randomIndex].sounds);
+    options.add(option);
+  }
+
+  return Array.from(options)
+    .sort(() => Math.random() - 0.5)
+    .slice(0, 4);
+};
+
+export default function HebrewLetterTrainer() {
+  const [score, setScore] = useState<Score>(INITIAL_SCORE);
+  const [currentIndex, setCurrentIndex] = useState(() => pickRandomIndex());
+  const [options, setOptions] = useState(() => buildOptionSet(currentIndex));
+  const [selectedOption, setSelectedOption] = useState<string | null>(null);
+
+  const correctOption = useMemo(
+    () => formatSounds(hebrewLetters[currentIndex].sounds),
+    [currentIndex]
+  );
+
+  useEffect(() => {
+    setOptions(buildOptionSet(currentIndex));
+    setSelectedOption(null);
+  }, [currentIndex]);
+
+  const goToNextLetter = useCallback(() => {
+    setCurrentIndex(prev => pickRandomIndex(prev));
+  }, []);
+
+  useEffect(() => {
+    if (!selectedOption) {
+      return;
+    }
+
+    const timeout = setTimeout(goToNextLetter, 900);
+    return () => clearTimeout(timeout);
+  }, [selectedOption, goToNextLetter]);
+
+  const handleOptionClick = (option: string) => {
+    if (selectedOption) {
+      return;
+    }
+
+    const isCorrect = option === correctOption;
+    setSelectedOption(option);
+    setScore(previous => ({
+      correct: previous.correct + (isCorrect ? 1 : 0),
+      incorrect: previous.incorrect + (isCorrect ? 0 : 1),
+    }));
+  };
+
+  const getOptionClassName = (option: string) => {
+    const baseStyles =
+      'relative flex items-center justify-center rounded-xl border-2 p-4 text-lg font-semibold transition-all duration-200 ease-out focus:outline-none';
+
+    if (!selectedOption) {
+      return `${baseStyles} border-slate-200 bg-white/80 shadow-sm hover:border-indigo-400 hover:shadow-lg`;
+    }
+
+    if (option === selectedOption && option === correctOption) {
+      return `${baseStyles} border-emerald-500 bg-emerald-50 text-emerald-900 shadow-[0_0_18px_rgba(16,185,129,0.55)]`;
+    }
+
+    if (option === selectedOption) {
+      return `${baseStyles} border-rose-500 bg-rose-50 text-rose-900 shadow-[0_0_18px_rgba(244,63,94,0.45)]`;
+    }
+
+    if (option === correctOption) {
+      return `${baseStyles} border-emerald-400 bg-emerald-50 text-emerald-900 shadow-[0_0_12px_rgba(16,185,129,0.3)]`;
+    }
+
+    return `${baseStyles} border-slate-200 bg-white/60 text-slate-500`;
+  };
+
+  return (
+    <div className="w-full">
+      <div className="mx-auto flex w-full max-w-lg flex-col gap-6 rounded-3xl border border-white/70 bg-white/80 p-6 shadow-xl backdrop-blur-lg sm:p-8">
+        <div className="flex items-center justify-between rounded-2xl bg-slate-900/90 px-6 py-4 text-white shadow-inner">
+          <div className="text-sm uppercase tracking-[0.3em] text-slate-200">Score</div>
+          <div className="text-right text-lg font-semibold">
+            <div className="text-emerald-300">Correct: {score.correct}</div>
+            <div className="text-rose-300">Incorrect: {score.incorrect}</div>
+          </div>
+        </div>
+
+        <div className="flex min-h-[10rem] flex-col items-center justify-center rounded-3xl border border-indigo-100 bg-gradient-to-br from-indigo-50 via-white to-emerald-50 p-10 text-center shadow-md">
+          <span className="sr-only">{hebrewLetters[currentIndex].name}</span>
+          <div className="text-7xl font-bold text-slate-900">
+            {hebrewLetters[currentIndex].letter}
+          </div>
+        </div>
+
+        <div className="grid grid-cols-2 gap-4">
+          {options.map(option => (
+            <button
+              key={option}
+              type="button"
+              className={getOptionClassName(option)}
+              onClick={() => handleOptionClick(option)}
+            >
+              {option}
+            </button>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/data/hebrewLetters.ts
+++ b/app/data/hebrewLetters.ts
@@ -1,0 +1,38 @@
+export interface HebrewLetter {
+  letter: string;
+  name: string;
+  sounds: string[];
+}
+
+export const hebrewLetters: HebrewLetter[] = [
+  { letter: 'א', name: 'Alef', sounds: ['Silent', 'Ah'] },
+  { letter: 'ב', name: 'Bet', sounds: ['B'] },
+  { letter: 'ג', name: 'Gimel', sounds: ['G'] },
+  { letter: 'ד', name: 'Dalet', sounds: ['D'] },
+  { letter: 'ה', name: 'He', sounds: ['H'] },
+  { letter: 'ו', name: 'Vav', sounds: ['V', 'O', 'U'] },
+  { letter: 'ז', name: 'Zayin', sounds: ['Z'] },
+  { letter: 'ח', name: 'Chet', sounds: ['Kh (like Bach)'] },
+  { letter: 'ט', name: 'Tet', sounds: ['T (Tet)'] },
+  { letter: 'י', name: 'Yod', sounds: ['Y', 'I'] },
+  { letter: 'כ', name: 'Kaf', sounds: ['Kh (Kaf)'] },
+  { letter: 'ך', name: 'Final Kaf', sounds: ['Kh (final)'] },
+  { letter: 'ל', name: 'Lamed', sounds: ['L'] },
+  { letter: 'מ', name: 'Mem', sounds: ['M'] },
+  { letter: 'ם', name: 'Final Mem', sounds: ['M (final)'] },
+  { letter: 'נ', name: 'Nun', sounds: ['N'] },
+  { letter: 'ן', name: 'Final Nun', sounds: ['N (final)'] },
+  { letter: 'ס', name: 'Samekh', sounds: ['S (Samekh)'] },
+  { letter: 'ע', name: 'Ayin', sounds: ['Ah (deep)', 'Silent throat'] },
+  { letter: 'פ', name: 'Pe', sounds: ['P'] },
+  { letter: 'ף', name: 'Final Pe', sounds: ['F (final)'] },
+  { letter: 'צ', name: 'Tsadi', sounds: ['Ts'] },
+  { letter: 'ץ', name: 'Final Tsadi', sounds: ['Ts (final)'] },
+  { letter: 'ק', name: 'Qof', sounds: ['K (deep)'] },
+  { letter: 'ר', name: 'Resh', sounds: ['R'] },
+  { letter: 'שׁ', name: 'Shin', sounds: ['Sh'] },
+  { letter: 'שׂ', name: 'Sin', sounds: ['S (Sin)'] },
+  { letter: 'ת', name: 'Tav', sounds: ['T (Tav)'] },
+];
+
+export const formatSounds = (sounds: string[]) => sounds.join(' · ');

--- a/app/globals.css
+++ b/app/globals.css
@@ -2,6 +2,11 @@
 @tailwind components;
 @tailwind utilities;
 
+html,
 body {
-  @apply bg-gradient-to-br from-indigo-100 via-white to-emerald-100 text-gray-800 flex justify-center items-start lg:items-center min-h-screen;
+  @apply min-h-screen;
+}
+
+body {
+  @apply bg-gradient-to-br from-indigo-100 via-white to-emerald-100 text-gray-900 antialiased;
 }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -2,15 +2,17 @@ import './globals.css';
 import { ReactNode } from 'react';
 
 export const metadata = {
-  title: 'Multilingual Typing Trainer',
-  description: 'Practice touch typing in multiple languages',
+  title: 'Hebrew Letter Sound Trainer',
+  description: 'Learn the sounds of the Hebrew alphabet with an interactive quiz.',
 };
 
 export default function RootLayout({ children }: { children: ReactNode }) {
   return (
     <html lang="en">
-      <body className="w-full">
-        {children}
+      <body className="min-h-screen w-full bg-slate-100/80 text-gray-900">
+        <div className="mx-auto flex min-h-screen w-full max-w-5xl items-stretch justify-center px-2 sm:px-6">
+          {children}
+        </div>
       </body>
     </html>
   );

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,9 +1,18 @@
-import TypingTrainer from './components/TypingTrainer';
+import HebrewLetterTrainer from './components/HebrewLetterTrainer';
 
 export default function Home() {
   return (
-    <main className="w-full max-w-xl p-4">
-      <TypingTrainer />
+    <main className="flex w-full max-w-3xl flex-1 flex-col items-center justify-center px-4 py-10 sm:py-16">
+      <div className="w-full max-w-xl">
+        <h1 className="mb-6 text-center text-3xl font-extrabold tracking-tight text-slate-900 sm:text-4xl">
+          Hebrew Letter Sound Trainer
+        </h1>
+        <p className="mb-8 text-center text-base text-slate-600 sm:text-lg">
+          Strengthen your Hebrew reading intuition by matching each letter with its sound.
+          Tap an answer to see instant feedback and grow your score.
+        </p>
+        <HebrewLetterTrainer />
+      </div>
     </main>
   );
 }


### PR DESCRIPTION
## Summary
- hide the transliterated name on the quiz letter card so only the Hebrew glyph is shown
- keep the name available to screen readers while maintaining centered letter styling

## Testing
- Not Run (npm run lint requires interactive configuration)


------
https://chatgpt.com/codex/tasks/task_e_68dfd58d7e4c83338fd2a7c8bd3467f2